### PR TITLE
Allow svg in mediafield

### DIFF
--- a/Assets/js/MediaField.js
+++ b/Assets/js/MediaField.js
@@ -264,6 +264,7 @@
 				var _large;
 				var _medium;
 				var _thumbnail;
+				var _orientation;
 
 				if (attachment.sizes !== undefined) {
 				  _full = ( attachment.sizes.full !== undefined ? attachment.sizes.full.url : '' );
@@ -284,7 +285,7 @@
 				self.$el.find( '#medium').val( _medium );
 				self.$el.find( '#large').val( _large );
 				self.$el.find( '#full').val( _full );
-				self.$el.find( '#orientation' ).val( attachment.sizes.full.orientation );
+				self.$el.find( '#orientation' ).val( _orientation );
 
 				self.$el.find( '#preview' ).attr( 'src', _thumbnail );
 

--- a/Assets/js/MediaField.js
+++ b/Assets/js/MediaField.js
@@ -260,10 +260,24 @@
 
 			Media.uploader( options, function( attachment, options ){
 						
-				var _full = ( attachment.sizes.full !== undefined ? attachment.sizes.full.url : '' );
-				var _large = ( attachment.sizes.large !== undefined ? attachment.sizes.large.url : '' );
-				var _medium = ( attachment.sizes.medium !== undefined ? attachment.sizes.medium.url : '' );
-				var _thumbnail = ( attachment.sizes.thumbnail !== undefined ? attachment.sizes.thumbnail.url : '' );
+				var _full;
+				var _large;
+				var _medium;
+				var _thumbnail;
+
+				if (attachment.sizes !== undefined) {
+				  _full = ( attachment.sizes.full !== undefined ? attachment.sizes.full.url : '' );
+				  _large = ( attachment.sizes.large !== undefined ? attachment.sizes.large.url : '' );
+				  _medium = ( attachment.sizes.medium !== undefined ? attachment.sizes.medium.url : '' );
+				  _thumbnail = ( attachment.sizes.thumbnail !== undefined ? attachment.sizes.thumbnail.url : '' );
+				  _orientation = ( attachment.sizes.full.orientation !== undefined ? attachment.sizes.full.orientation : '' );
+				} else {
+				  _full = ( attachment.url !== undefined ? attachment.url : '' );
+				  _large = ( attachment.url !== undefined ? attachment.url : '' );
+				  _medium = ( attachment.url !== undefined ? attachment.url : '' );
+				  _thumbnail = ( attachment.url !== undefined ? attachment.url : '' );
+				  _orientation = ''
+				}
 
 				self.$el.find( '#img-id' ).val( attachment.id );
 				self.$el.find( '#thumb').val( _thumbnail );


### PR DESCRIPTION
Hi guys,

First of all, cuisine is great! It saves me a ton of time when working with metaboxes, custom post types and input fields in general. Thanks for that!

In a lot of our projects, we allow clients to upload svg files for vector images. When selecting an svg trough the media uploader, the sizes object is not defined though, which results in an error in the Media field. I've made some small changes to the MediaField file that checks if attachment.sizes is set, if it isn't, it assumes that it can use the file url for all sizes.

I know it's a bit of an edge case, but perhaps it can come in handy.

